### PR TITLE
Update mount path to not clash with maven

### DIFF
--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -55,7 +55,7 @@ def call(body) {
   /* Only mount registry secret if it's present */
   def volumes = [ hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock') ]
   if (registrySecret) {
-    volumes += secretVolume(secretName: registrySecret, mountPath: '/root')
+    volumes += secretVolume(secretName: registrySecret, mountPath: '/msb_reg_sec')
   }
   print "microserviceBuilderPipeline: volumes = ${volumes}"
 
@@ -96,7 +96,7 @@ def call(body) {
                 if (!registry.endsWith('/')) {
                   registry = "${registry}/"
                 }
-                sh "ln -s /root/.dockercfg /home/jenkins/.dockercfg"
+                sh "ln -s /msb_reg_sec/.dockercfg /home/jenkins/.dockercfg"
                 sh "docker tag ${image}:${gitCommit} ${registry}${image}:${gitCommit}"
                 sh "docker push ${registry}${image}:${gitCommit}"
               }


### PR DESCRIPTION
The local maven repository expects to write to /root/.m2 but the pipeline is mounting a secret at /root which appears to cause intermittent issues with maven downloading files to the local repository.