### PR TITLE
Check chart folder exists before running tests

### DIFF
--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -141,7 +141,7 @@ def call(body) {
          It's only a local change and not committed back to git. */
       sh "find ${chartFolder} ${manifestFolder} -type f | xargs sed -i \'s|\\(image:\\s*\\)\\(.*\\):latest|\\1${registry}\\2:${gitCommit}|g\'"
 
-      if (test && fileExists('pom.xml')) {
+      if (test && fileExists('pom.xml') && fileExists(chartFolder)) {
         stage ('Verify') {
           String tempHelmRelease = (image + "-" + testNamespace).substring(0,52) // 53 is max length in Helm
           container ('kubectl') {


### PR DESCRIPTION
A small bug exists where testing attempts to run when the application does not have a helm chart - testing is only supported for helm tests and as such if there is no chart folder the test phase should do nothing.