### PR TITLE
Modifications to helm chart installations

### DIFF
--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -275,9 +275,14 @@ def getChartFolder(String userSpecified, String currentChartFolder) {
             return newChartLocation
         }
       } else {
-          newChartLocation = currentChartFolder + "/" + dirList.get(0).getName()
-          print "Only one child directory found, setting realChartFolder to: ${newChartLocation}"
-          return newChartLocation
+          if (dirList.size() == 1) {
+            newChartLocation = currentChartFolder + "/" + dirList.get(0).getName()
+            print "Only one child directory found, setting realChartFolder to: ${newChartLocation}"
+            return newChartLocation
+	  } else {
+            print "Chart directory has no subdirectories, incorrect configuration"
+	    return null
+	  }
       }
     }
 }

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -66,7 +66,6 @@ def call(body) {
   // will need to check later if user provided chartFolder location
   def userSpecifiedChartFolder = config.chartFolder 
   def chartFolder = userSpecifiedChartFolder ?: ((System.getenv("CHART_FOLDER") ?: "").trim() ?: 'chart')
-  def chartFolder = config.chartFolder ?: ((System.getenv("CHART_FOLDER") ?: "").trim() ?: 'chart')
   def manifestFolder = config.manifestFolder ?: ((System.getenv("MANIFEST_FOLDER") ?: "").trim() ?: 'manifests')
 
   print "microserviceBuilderPipeline: registry=${registry} registrySecret=${registrySecret} build=${build} \

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -172,7 +172,9 @@ def call(body) {
                 container ('kubectl') {
                   sh "kubectl delete namespace ${testNamespace}"
                   if (fileExists(realChartFolder)) { 
-                    sh "helm delete ${tempHelmRelease} --purge"
+		    container ('helm') {
+                      sh "helm delete ${tempHelmRelease} --purge"
+		    }
                   }
                 }
               }

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -279,7 +279,9 @@ def getChartFolder(String userSpecified, String currentChartFolder) {
               print "Chart.yaml found in ${newChartLocation}, setting as realChartFolder"
               return newChartLocation
 	    } else {
+	        print "-----------------------------------------------------------"
 	        print "*** No sub directory in ${env.WORKSPACE}/${currentChartFolder} contains a Chart.yaml, returning null"
+		print "-----------------------------------------------------------"
 	        return null
 	    }
         }
@@ -291,11 +293,15 @@ def getChartFolder(String userSpecified, String currentChartFolder) {
               print "Only one child directory found, setting realChartFolder to: ${newChartLocation}"
               return newChartLocation
 	    } else {
+	        print "-----------------------------------------------------------"
                 print "*** Chart.yaml file does not exist in ${newChartLocation}, returning null"
+		print "-----------------------------------------------------------"
 		return null
 	    }
 	  } else {
+	      print "-----------------------------------------------------------"
               print "*** Chart directory ${env.WORKSPACE}/${currentChartFolder} has no subdirectories, incorrect configuration, returning null"
+	      print "-----------------------------------------------------------"
 	      return null
 	  }
       }


### PR DESCRIPTION
A well formed Helm deployment would have a three tier directory structure
to the Chart.yaml ..... of a form similar to project_name/chart/app_name.
This modification to the deployment code:

1) Assumes if the user chose too edit their Jenkinsfile and override the
config.chartFolder - said config.chartFolder would be specified
as"chart/app_name"

2) A system wide default if specified, is specified as defining what the
system wide default name is for the folder which defaults its name as
"chart". It makes no sense to have a system wide name for "chart/app-name"
as

3) Where multiple directories exist under "chart" (or equiv if overriden
by system property):

  - if only one of those subdirectories contains a Chart.yaml, this
    directory will be used as the chart folder for deployment purposes

  - if mutiple subdirectories contain Chart.yaml folder, the first folder
    will be chosen???? or maybe no directory should be returned??