### PR TITLE
Add in --pull option

### DIFF
--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -166,6 +166,7 @@ def call(body) {
           container ('helm') {
             sh "helm init --client-only"
             sh "helm install ${realChartFolder} --set test=true --namespace ${testNamespace} --name ${tempHelmRelease} --wait"
+	    sh "kubectl get all --namespace ${testNamespace}"
           }
 
           container ('maven') {
@@ -174,6 +175,7 @@ def call(body) {
             } finally {
               step([$class: 'JUnitResultArchiver', allowEmptyResults: true, testResults: '**/target/failsafe-reports/*.xml'])
               step([$class: 'ArtifactArchiver', artifacts: '**/target/failsafe-reports/*.txt', allowEmptyArchive: true])
+	      sh "kubectl get all --namespace ${testNamespace}"
               if (!debug) {
                 container ('kubectl') {
                   sh "kubectl delete namespace ${testNamespace}"

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -122,7 +122,7 @@ def call(body) {
         if (fileExists('Dockerfile')) {
           stage ('Docker Build') {
             container ('docker') {
-              sh "docker build -t ${image}:${gitCommit} ."
+              sh "docker build --pull=true -t ${image}:${gitCommit} ."
               if (registry) { 
                 if (!registry.endsWith('/')) {
                   registry = "${registry}/"

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -166,9 +166,7 @@ def call(body) {
           container ('helm') {
             sh "helm init --client-only"
             sh "helm install ${realChartFolder} --set test=true --namespace ${testNamespace} --name ${tempHelmRelease} --wait"
-	    sh "kubectl get all --namespace ${testNamespace}"
 	    sh "sleep 10"
-	    sh "echo Testingagain"
 	    sh "kubectl get all --namespace ${testNamespace}"
           }
 
@@ -178,7 +176,6 @@ def call(body) {
             } finally {
               step([$class: 'JUnitResultArchiver', allowEmptyResults: true, testResults: '**/target/failsafe-reports/*.xml'])
               step([$class: 'ArtifactArchiver', artifacts: '**/target/failsafe-reports/*.txt', allowEmptyArchive: true])
-	      sh "kubectl get all --namespace ${testNamespace}"
               if (!debug) {
                 container ('kubectl') {
                   sh "kubectl delete namespace ${testNamespace}"

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -167,6 +167,9 @@ def call(body) {
             sh "helm init --client-only"
             sh "helm install ${realChartFolder} --set test=true --namespace ${testNamespace} --name ${tempHelmRelease} --wait"
 	    sh "kubectl get all --namespace ${testNamespace}"
+	    sh "sleep 10"
+	    sh "echo Testingagain"
+	    sh "kubectl get all --namespace ${testNamespace}"
           }
 
           container ('maven') {


### PR DESCRIPTION
This has been implemented so we always pull down the latest image of WebSphere Liberty. If one exists on the node from a previous build the user will never get a new version of the Liberty image unless this is set.