### PR TITLE
Add --pull arg to docker build command

### DIFF
--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -128,7 +128,7 @@ def call(body) {
         if (fileExists('Dockerfile')) {
           stage ('Docker Build') {
             container ('docker') {
-              def buildCommand = "docker build -t ${image}:${gitCommit}"
+              def buildCommand = "docker build --pull=true -t ${image}:${gitCommit}"
               if (libertyLicenseJarBaseUrl) {
                 if (readFile('Dockerfile').contains('LICENSE_JAR_URL')) {
                   buildCommand += " --build-arg LICENSE_JAR_URL=" + libertyLicenseJarBaseUrl


### PR DESCRIPTION
I have added the --pull=true arg to the docker build command so that we pull down the newest version of liberty regardless of what version we have stored in the registry so that we are always up to date.