### PR TITLE
Move maven back to 3.5.0-jdk-8

### DIFF
--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -11,7 +11,7 @@
   The following parameters may also be specified. Their defaults are shown below.
   These are the names of images to be downloaded from https://hub.docker.com/.
 
-    mavenImage = 'maven:jdk-8'
+    mavenImage = 'maven:3.5.0-jdk-8'
     dockerImage = 'docker'
     kubectlImage = 'ibmcom/k8s-kubectl:v1.7.6'
     helmImage = 'ibmcom/k8s-helm:v2.5.0'
@@ -49,7 +49,7 @@ def call(body) {
   print "microserviceBuilderPipeline : config = ${config}"
 
   def image = config.image
-  def maven = (config.mavenImage == null) ? 'maven:jdk-8' : config.mavenImage
+  def maven = (config.mavenImage == null) ? 'maven:3.5.0-jdk-8' : config.mavenImage
   def docker = (config.dockerImage == null) ? 'docker' : config.dockerImage
   def kubectl = (config.kubectlImage == null) ? 'ibmcom/k8s-kubectl:v1.7.6' : config.kubectlImage
   def helm = (config.helmImage == null) ? 'ibmcom/k8s-helm:v2.5.0' : config.helmImage


### PR DESCRIPTION
There is no longer a maven:jdk-8 - the manifest support for multi platform appears to now be in 3.5.0-jdk-8 so switching back.