### PR TITLE
Fully qualify the helm command in the new image

### DIFF
--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -180,8 +180,8 @@ def call(body) {
           }
           // We're moving to Helm-only deployments. Use Helm to install a deployment to test against.
           container ('helm') {
-            sh "helm init --client-only"
-            def deployCommand = "helm install ${realChartFolder} --wait --set test=true --values pipeline.yaml --namespace ${testNamespace} --name ${tempHelmRelease}"
+            sh "/helm init --client-only --skip-refresh"
+            def deployCommand = "/helm install ${realChartFolder} --wait --set test=true --values pipeline.yaml --namespace ${testNamespace} --name ${tempHelmRelease}"
             if (fileExists("chart/overrides.yaml")) {
               deployCommand += " --values chart/overrides.yaml"
             }
@@ -199,7 +199,7 @@ def call(body) {
                   sh "kubectl delete namespace ${testNamespace}"
                   if (fileExists(realChartFolder)) {
                     container ('helm') {
-                      sh "helm delete ${tempHelmRelease} --purge"
+                      sh "/helm delete ${tempHelmRelease} --purge"
                     }
                   }
                 }
@@ -221,8 +221,8 @@ def call(body) {
 def deployProject (String chartFolder, String registry, String image, String imageTag, String namespace, String manifestFolder) {
   if (chartFolder != null && fileExists(chartFolder)) {
     container ('helm') {
-      sh "helm init --client-only"
-      def deployCommand = "helm upgrade --install --wait --values pipeline.yaml"
+      sh "/helm init --client-only --skip-refresh"
+      def deployCommand = "/helm upgrade --install --wait --values pipeline.yaml"
       if (fileExists("chart/overrides.yaml")) {
         deployCommand += " --values chart/overrides.yaml"
       }


### PR DESCRIPTION
The helm image does not have helm on the path, we can workaround this (as we don't control the image) by fully qualifying the command.  Additionally it does not contain the ca certs, but we can use --skip-refresh on the helm init command to stop that failing.