### PR TITLE
Inherit from default pod template

### DIFF
--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -91,6 +91,7 @@ def call(body) {
 
     podTemplate(
     label: 'msbPod',
+    inheritFrom: 'default',
     containers: [
       containerTemplate(name: 'maven', image: maven, ttyEnabled: true, command: 'cat',
         envVars: [


### PR DESCRIPTION
In order to pick up the correct slave image defined in the Jenkins chart, we need to inherit from the default pod template created by the chart.