### PR TITLE
Tolerate multiple image entries, only add repo to ${image}

### DIFF
--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -162,10 +162,8 @@ def call(body) {
         if (imageTag) yamlContent += "\n  tag: \\\"${imageTag}\\\""
         sh "echo \"${yamlContent}\" > pipeline.yaml"
       } else {
-        if (!sh (script: "grep -h -r image:.* ${manifestFolder}", returnStdout: true).contains("/")) {
-          sh "find ${manifestFolder} -type f | xargs sed -i \'s|\\(image:\\s*\\)\\(.*\\)|\\1${registry}\\2|g\'"
-        } 
-        sh "find ${manifestFolder} -type f | xargs sed -i -e 's/:latest/:${gitCommit}/g'"
+        sh "find ${manifestFolder} -type f | xargs sed -i 's|\\(image:\\s*\\)${image}:latest|\\1${registry}${image}:latest|g'"
+        sh "find ${manifestFolder} -type f | xargs sed -i 's|\\(image:\\s*\\)${registry}${image}:latest|\\1${registry}${image}:${gitCommit}|g'"
       }
 
       if (test && fileExists('pom.xml') && realChartFolder != null && fileExists(realChartFolder)) {


### PR DESCRIPTION
We found a bug in which yams such as that pre-processed by Istio could contain image: entries with / characters in, and image: entries without. Our ':latest: processing needed to be tightened so as only to apply to the image: ${image} entry. 